### PR TITLE
trying to make it compile/run

### DIFF
--- a/AppleScript.cabal
+++ b/AppleScript.cabal
@@ -38,8 +38,9 @@ if os(darwin) {
                         network < 2.4,
                         conduit < 0.3,
                         directory < 1.2,
-                        template-haskell == 2.7.*,
-                        mtl == 2.0.*
+                        template-haskell >= 2.7,
+                        mtl >= 2.0,
+                        resourcet == 1.1.3
   Exposed-modules:
                         Foreign.AppleScript
                         Foreign.AppleScript.Error

--- a/Foreign/AppleScript/Rich.hs
+++ b/Foreign/AppleScript/Rich.hs
@@ -7,7 +7,7 @@
    TypeSynonymInstances, 
    FlexibleInstances 
  #-}
-{-# OPTIONS_GHC -funbox-strict-fields -Wall -Werror #-}
+{-# OPTIONS_GHC -funbox-strict-fields -Wall #-}
 
 -- |
 -- This module supports a \"rich\" communication with AppleScript. Specifically, this
@@ -72,7 +72,7 @@ import qualified Foreign.AppleScript.Plain as Plain
 import Control.Applicative
 import Control.Monad.State
 import Control.Monad.Writer
-import Control.Monad.Trans.Resource(ResourceT, runResourceT, withIO)
+import Control.Monad.Trans.Resource(ResourceT, runResourceT, allocate)
 
 import Control.Exception(tryJust, finally)
 import Control.Concurrent(forkIO, killThread)
@@ -276,11 +276,11 @@ runScriptFull conf script = runResourceT $ do
 
       -- start the callback server
       (_, sock) <- lift $
-        withIO
+        allocate
           (listenOn (PortNumber port))
           sClose
           -- (const $ return ())
-      void $ lift $ withIO
+      void $ lift $ allocate
         (forkIO $ serverLoop handler sock)
         killThread
 


### PR DESCRIPTION
I'm trying to get this to compile with a newer version of resourcet for example. With the changes below (and --allow-newer, I didn't change all the bounds yet), it compiles successfully, and the examples which are one-way to AppleScript work (like opening a browser page), but the ones that require input (like HelloThere or Rich) don't (they just wait for input). 

It would be great if we could get this updated to be easily installable on more modern systems - you don't need to accept this pull request though. 
