### PR TITLE
Made the library stack compatible, removed upper bounds & made it compile again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.stack-work

--- a/AppleScript.cabal
+++ b/AppleScript.cabal
@@ -1,5 +1,5 @@
 Name:			AppleScript
-Version:		0.2.0.1
+Version:		0.2.0.2
 License:		BSD3
 License-file:		LICENSE
 Author:			Wouter Swierstra <wouter.swierstra@gmail.com>, Reiner Pope <reiner.pope@gmail.com>
@@ -30,16 +30,17 @@ Library {
 if os(darwin) {
   Buildable:		True
   Build-Depends:        base >= 2 && < 5,
-                        bytestring < 0.10,
-                        data-default < 0.4,
-                        text < 0.12,
-                        haskell-src-meta >= 0.5.0.3 && < 0.6,
-                        text-format < 0.4,
-                        network < 2.4,
-                        conduit < 0.3,
-                        directory < 1.2,
-                        template-haskell == 2.7.*,
-                        mtl == 2.0.*
+                        bytestring,
+                        data-default,
+                        text,
+                        haskell-src-meta >= 0.5.0.3,
+                        text-format,
+                        network,
+                        conduit,
+                        resourcet,
+                        directory,
+                        template-haskell >= 2.7.0.0,
+                        mtl
   Exposed-modules:
                         Foreign.AppleScript
                         Foreign.AppleScript.Error

--- a/Foreign/AppleScript/Rich.hs
+++ b/Foreign/AppleScript/Rich.hs
@@ -1,11 +1,11 @@
-{-# LANGUAGE 
-   TemplateHaskell, 
-   OverloadedStrings, 
-   ExistentialQuantification, 
-   ViewPatterns, 
-   TupleSections, 
-   TypeSynonymInstances, 
-   FlexibleInstances 
+{-# LANGUAGE
+   TemplateHaskell,
+   OverloadedStrings,
+   ExistentialQuantification,
+   ViewPatterns,
+   TupleSections,
+   TypeSynonymInstances,
+   FlexibleInstances
  #-}
 {-# OPTIONS_GHC -funbox-strict-fields -Wall -Werror #-}
 
@@ -27,14 +27,14 @@
 -- >   tell application "System Events"
 -- >     -- Haskell value splices, and Unicode support.
 -- >     display dialog "The value of π is $value{pi :: Double}$."
--- > 
+-- >
 -- >     -- AppleScript can call back into Haskell.
 -- >     set yourName to text returned of (display dialog "What is your name?" default answer "")
 -- >     display dialog ("Your name in reverse is " & $callback{ \t -> return (Text.reverse t) }$[ yourName ]$)
--- > 
+-- >
 -- >     -- Splice other AppleScript code into here
 -- >     $applescript{ othergreeter }$
--- > 
+-- >
 -- >     -- Return text from AppleScript back to Haskell
 -- >     return "Hello from AppleScript!"
 -- >   end tell
@@ -52,6 +52,7 @@ module Foreign.AppleScript.Rich
   -- * Common-use functions
   Plain.appleScriptAvailable,
   applescript,
+  applescriptplain,
   runScript,
   evalScript,
   debugScript,
@@ -63,16 +64,15 @@ module Foreign.AppleScript.Rich
   -- * Configuration
   AppleScriptConfig(..),
   def,
-  ) 
+  )
   where
 
 import           Foreign.AppleScript.Error
 import qualified Foreign.AppleScript.Plain as Plain
 
-import Control.Applicative
 import Control.Monad.State
 import Control.Monad.Writer
-import Control.Monad.Trans.Resource(ResourceT, runResourceT, withIO)
+import Control.Monad.Trans.Resource(ResourceT, runResourceT, allocate)
 
 import Control.Exception(tryJust, finally)
 import Control.Concurrent(forkIO, killThread)
@@ -275,12 +275,11 @@ runScriptFull conf script = runResourceT $ do
       port <- liftIO $ portGen conf
 
       -- start the callback server
-      (_, sock) <- lift $
-        withIO
+      (_, sock) <- lift $ allocate
           (listenOn (PortNumber port))
           sClose
           -- (const $ return ())
-      void $ lift $ withIO
+      void $ lift $ allocate
         (forkIO $ serverLoop handler sock)
         killThread
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,5 @@
+flags: {}
+packages:
+- '.'
+extra-deps: []
+resolver: lts-3.0


### PR DESCRIPTION
We might want to review the optimal upper bound for packages (but they are not needed if the end user will be using stack & stackage), but essentially this now builds against a modern Haskell stack.
`conduit` since early versions split `resourcet` into a separate package, and this patch reflects this as well.
